### PR TITLE
Move JWT tokens to headers

### DIFF
--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -18,11 +18,9 @@ export const authorized = async (req: AuthRequest, res: Response, next: NextFunc
     const authHeader = req.headers.authorization;
     let token: string | undefined;
 
-    // Tries to retrieve the token from either the Authorization header (standard "Bearer <token>") or cookies (accessToken cookie)
+    // Retrieve the token from the Authorization header ("Bearer <token>")
     if (authHeader && authHeader.startsWith("Bearer ")) {
       token = authHeader.split(" ")[1];
-    } else if (req.cookies?.accessToken) {
-      token = req.cookies.accessToken;
     }
 
     // Throws a 401 error if no token is found

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -73,7 +73,7 @@ const signIn = async (
   return { user, accessToken, refreshToken };
 };
 
-// Accepts a refreshToken, from cookies or request body
+// Accepts a refreshToken provided in a request header or body
 const refreshToken = async (
   token: string
 ): Promise<{


### PR DESCRIPTION
## Summary
- send access and refresh tokens via response headers
- read tokens from headers in auth middleware and refresh handler

## Testing
- `npm run build` *(fails: Cannot find type definition file for packages)*

------
https://chatgpt.com/codex/tasks/task_e_6877eebff4e88323ac2e72602bf6757a